### PR TITLE
Strip a leading '@' from usernames

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -325,10 +325,17 @@ fn try_main(log: &mut Log) -> Result<()> {
             process::exit(0);
         }
         let mut parts = arg.splitn(2, '/');
-        let user = parts.next().unwrap().to_owned();
+        let user = parts.next().unwrap();
         match parts.next() {
-            Some(repo) => args.push(Series::Repo(user, repo.to_owned())),
-            None => args.push(Series::User(user)),
+            Some(repo) => {
+                let user = user.to_owned();
+                let repo = repo.to_owned();
+                args.push(Series::Repo(user, repo));
+            }
+            None => {
+                let user = user.strip_prefix('@').unwrap_or(user).to_owned();
+                args.push(Series::User(user));
+            }
         }
     }
 


### PR DESCRIPTION
My https://github.com/dtolnay/cargo-tally crate uses `cargo tally cratename` for individual crates and `cargo tally @username` for GitHub users. In `star-history` the individual repos are disambiguated by the presence of a `/` instead of absence of a `@`. But someone who uses both crates will find it frustrating that `star-history @username` does not just work.

```console
Error from GitHub api: Could not resolve to a User with the login of '@dtolnay'.
Error: no such user: @dtolnay
```