### PR TITLE
Include millis in generated filename timestamp

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -494,7 +494,7 @@ fn try_main(log: &mut Log) -> Result<()> {
     let html = include_str!("index.html").replace("var data = [];", &data);
     let dir = env::temp_dir().join("star-history");
     fs::create_dir_all(&dir)?;
-    let path = dir.join(format!("{}.html", now.timestamp()));
+    let path = dir.join(format!("{}.html", now.timestamp_millis()));
     fs::write(&path, html)?;
 
     if opener::open(&path).is_err() {


### PR DESCRIPTION
This matches what https://github.com/dtolnay/cargo-tally does.

Millis is helpful because seconds can much more easily have a collision if someone is running multiple `star-history` commands in parallel and they finish in the same second. Perhaps we should do some kind of linear scan in the event of collision, but millis is really good enough.

```rust
use std::fs::OpenOptions;
use std::io::{self, Write};

let mut timestamp = now.timestamp();
let mut file = loop {
    let filename = format!("{}.html", timestamp);
    match OpenOptions::new().write(true).create_new(true).open(filename) {
        Ok(file) => break file,
        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => timestamp += 1,
        Err(err) => return Err(err),
    }
};
file.write_all(content)?;
```