### PR TITLE
Do to_string_lossy conversion for non-utf8 GITHUB_TOKEN

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -338,9 +338,9 @@ fn try_main(log: &mut Log) -> Result<()> {
         }
     }
 
-    let authorization = match env::var("GITHUB_TOKEN") {
-        Ok(token) => format!("bearer {}", token.trim()),
-        Err(_) => {
+    let authorization = match env::var_os("GITHUB_TOKEN") {
+        Some(token) => format!("bearer {}", token.to_string_lossy().trim()),
+        None => {
             eprint!("{}", MISSING_TOKEN);
             process::exit(1);
         }


### PR DESCRIPTION
GitHub's tokens are always valid UTF8 and do not contain U+FFFD. So if the user's environment variable has a non-UTF8 value, it makes more sense to let GitHub respond telling them their token is wrong, instead of saying the token isn't set.