### PR TITLE
Trim gh token retrieved via CLI

### DIFF
--- a/gh-token/src/lib.rs
+++ b/gh-token/src/lib.rs
@@ -164,5 +164,9 @@ fn config_dir() -> Option<PathBuf> {
 
 fn token_from_cli() -> Option<String> {
     let output = Command::new("gh").arg("auth").arg("token").output().ok()?;
-    String::from_utf8(output.stdout).ok()
+    let mut token = String::from_utf8(output.stdout).ok()?;
+    // Trim the captured trailing newline from CLI output
+    let token_len = token.trim_end().len();
+    token.truncate(token_len);
+    Some(token)
 }


### PR DESCRIPTION
`gh auth token` outputs a newline after the token. Some usage tolerates
this, but some doesn't, so it's better practice to remove it here.

Noticed [by cargo-binstall](https://github.com/cargo-bins/cargo-binstall/issues/1333) which wasn't trimming the token previously. They switched to just invoking `gh auth token` directly, but it's still a good idea to do this for the next downstream.

The use in star-history already had a trim, so that's why it wasn't caught there.