### PR TITLE
Reduce graphql api page sizes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -544,7 +544,7 @@ fn query_owner(i: usize, login: &str, cursor: &Cursor) -> String {
     r#"
         owner$i: repositoryOwner(login: "$login") {
           login
-          repositories(after: $cursor, first: 100, isFork: false, privacy: PUBLIC, ownerAffiliations: [OWNER]) {
+          repositories(after: $cursor, first: 10, isFork: false, privacy: PUBLIC, ownerAffiliations: [OWNER]) {
             pageInfo {
               hasNextPage
               endCursor
@@ -570,7 +570,7 @@ fn query_repo(i: usize, owner: &str, repo: &str, cursor: &Cursor) -> String {
           owner {
             login
           }
-          stargazers(after: $cursor, first: 100) {
+          stargazers(after: $cursor, first: 20) {
             pageInfo {
               hasNextPage
               endCursor


### PR DESCRIPTION
This appears to alleviate errors that look like:

> Error from GitHub api: Something went wrong while executing your query on 2025-03-25T04:48:34+00:00. This may be the result of a timeout, or it could be a GitHub bug. Please include `8D8C:2CAA82:1F7EDE5:207AE41:67E23597` when reporting this issue.

which were causing incomplete results.